### PR TITLE
Improve rendering, reduce ttfp.

### DIFF
--- a/hugo/themes/quigs/layouts/_default/baseof.html
+++ b/hugo/themes/quigs/layouts/_default/baseof.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
+<head>
     {{- partial "head.html" . -}}
+</head>
     <body>
         {{- partial "header.html" . -}}
         <div id="content">

--- a/hugo/themes/quigs/layouts/_default/list.html
+++ b/hugo/themes/quigs/layouts/_default/list.html
@@ -1,3 +1,5 @@
-{{ partial "header.html" . }}
+<head>
 {{ partial "head.html" . }}
+</head>
+{{ partial "header.html" . }}
 {{ partial "list.html" . }}

--- a/hugo/themes/quigs/layouts/_default/list.html
+++ b/hugo/themes/quigs/layouts/_default/list.html
@@ -1,1 +1,3 @@
+{{ partial "header.html" . }}
+{{ partial "head.html" . }}
 {{ partial "list.html" . }}

--- a/hugo/themes/quigs/layouts/_default/single.html
+++ b/hugo/themes/quigs/layouts/_default/single.html
@@ -1,3 +1,5 @@
+<head>
+{{ partial "head.html" . }}
+</head>
 {{- partial "header.html" . -}}
-{{- partial "head.html" . -}}
 {{- partial "page.html" . -}}

--- a/hugo/themes/quigs/layouts/partials/head.html
+++ b/hugo/themes/quigs/layouts/partials/head.html
@@ -1,5 +1,6 @@
 <head>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="{{ "css/home.css" | absURL }}">
+  <link rel="stylesheet" href="{{ "css/list.css" | absURL }}">
   {{ .Hugo.Generator }}
 </head>

--- a/hugo/themes/quigs/layouts/partials/head.html
+++ b/hugo/themes/quigs/layouts/partials/head.html
@@ -1,6 +1,4 @@
-<head>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="{{ "css/home.css" | absURL }}">
   <link rel="stylesheet" href="{{ "css/list.css" | absURL }}">
   {{ .Hugo.Generator }}
-</head>

--- a/hugo/themes/quigs/layouts/partials/list.html
+++ b/hugo/themes/quigs/layouts/partials/list.html
@@ -1,6 +1,6 @@
 {{ partial "header.html" . }}
 {{ partial "head.html" . }}
-<section class="container list">
+<section class="list-container">
   <h1 class="title">{{ .Title }}</h1>
   <ul>
     {{ range .Paginator.Pages }}

--- a/hugo/themes/quigs/layouts/partials/list.html
+++ b/hugo/themes/quigs/layouts/partials/list.html
@@ -1,5 +1,3 @@
-{{ partial "header.html" . }}
-{{ partial "head.html" . }}
 <section class="list-container">
   <h1 class="title">{{ .Title }}</h1>
   <ul>

--- a/hugo/themes/quigs/layouts/partials/post.html
+++ b/hugo/themes/quigs/layouts/partials/post.html
@@ -1,5 +1,3 @@
-{{ partial "header.html" . }}
-{{ partial "head.html" . }}
 <section class="container page">
   <h1 class="title">{{ .Title }}</h1>
   <h2 class="date">{{ .Date.Format "January 2, 2006" }}</h2>

--- a/hugo/themes/quigs/static/css/list.css
+++ b/hugo/themes/quigs/static/css/list.css
@@ -1,0 +1,22 @@
+.list-container {
+  text-align: center;
+}
+
+.list-container li {
+  border-radius: 10px 10px 10px 10px;
+  margin-left: 20%;
+  margin-right: 20%;
+  margin-top: 5%;
+  margin-bottom: 5%;
+  padding: 8px;
+  border-style: outset;
+}
+
+.list-container a {
+  padding: 10px;
+  text-decoration: none;
+}
+
+.list-container img {
+  float: left;
+}


### PR DESCRIPTION
# What changed?
Moved heading content to parent layouts for the theme to improve time to paint and remove navbar re-loading each time the page is changed.